### PR TITLE
Added passthrough, timer and sync features 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ See JSON file??
 
 * Allow always passthrough. Passes message throuh (on/off) even if state is the same. Allow better repeats for 433Mhz etc
 
+## Changes
+1. An On message can be passed through by setting `payload.onMsg` to a message to output.
+2. An On message with `payload.override` set to `true` or `1` will always send the message even if the state is already On.   
+3. An Off message can be set in the Properties which will be output instead of the usual Off message.
+4. Turning off the timer using `set` doesn't stop the timer from running it just prevents the Off msg from being set
+5. Re-enabling the timer using `set` or `reset` allows the Off msg to be sent when the timer expires
+6. `reset` ony resets the timer to the value set in Properties if the timer currently left on the timer is less

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ See JSON file??
 3. An Off message can be set in the Properties which will be output instead of the usual Off message.
 4. Turning off the timer using `set` doesn't stop the timer from running it just prevents the Off msg from being set
 5. Re-enabling the timer using `set` or `reset` allows the Off msg to be sent when the timer expires
-6. `reset` ony resets the timer to the value set in Properties if the timer currently left on the timer is less
+6. `reset` ony resets the timer to the value set in Properties if the time currently left on the timer is less

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ See JSON file??
 4. Turning off the timer using `set` doesn't stop the timer from running it just prevents the Off msg from being set
 5. Re-enabling the timer using `set` or `reset` allows the Off msg to be sent when the timer expires
 6. `reset` ony resets the timer to the value set in Properties if the time currently left on the timer is less
+7. Added `sync` feature that allows the actual device to sync its state with the node without a message being output

--- a/smartswitch/smartswitch.html
+++ b/smartswitch/smartswitch.html
@@ -29,6 +29,11 @@
     </div>
 
     <div class="form-row">
+        <label for="node-input-offmsg"><i class="fa fa-envelope"></i> Off Msg</label>
+        <input type="text" id="node-input-offMsg" placeholder="{'topic': 'switch', 'payload':{'value':0}}">
+    </div>
+
+    <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
@@ -44,8 +49,8 @@
 		<li>topic "toggle" = toggle current state</li>
 		<li>topic "state" = payload is 1 ON or 0 OFF</li>
 		<li>topic "reset" = reset the timer if on</li>
-		<li>topic "set" = set timeout to new number if turned on</li>
-		<li>topic "timeout" = payload is 1 Enable, 0 Disable timeout function</li>
+		<li>topic "set" = payload is 1 Enable, 0 Disable timeout function</li>
+		<li>topic "timeout" =  set timeout to new number if turned on</li>
 	</ul>
 </script>
 
@@ -57,7 +62,8 @@
         defaults: {             // defines the editable properties of the node
             name: {value:""},   //  along with default values.
             topic: {value:"", required:true},
-			timeout: {value:"0"}
+            timeout: {value:"0"},
+            offMsg: {value: "", validate: RED.validators.typedInput('offMsgType')}
         },
         inputs:1,	// INPUT - Various inputs using payloads
         outputs:1,  // OUPTUT - Payload, ON only payload, OFF only payload
@@ -68,6 +74,12 @@
         },
         labelStyle: function() { // TODO
             return this.name?"node_label_italic":"";
+        },
+        oneditprepare: function() {
+            $('#node-input-offMsg').typedInput({
+                default: 'json',
+                types: ['json']
+            });
         }
     });
 </script>

--- a/smartswitch/smartswitch.html
+++ b/smartswitch/smartswitch.html
@@ -50,7 +50,8 @@
 		<li>topic "state" = payload is 1 ON or 0 OFF</li>
 		<li>topic "reset" = reset the timer if on</li>
 		<li>topic "set" = payload is 1 Enable, 0 Disable timeout function</li>
-		<li>topic "timeout" =  set timeout to new number if turned on</li>
+        <li>topic "timeout" =  set timeout to new number if turned on</li>
+        <li>topic "sync" = set the sate without sending a message<li>
 	</ul>
 </script>
 

--- a/smartswitch/smartswitch.js
+++ b/smartswitch/smartswitch.js
@@ -161,8 +161,8 @@ module.exports = function(RED) {
 				else if (msg.topic.endsWith("/SWAP")) 
 					stateSwitch = !stateSwitch;
 				
-				// Always send an On or Off as there may be a change in onMsg
-				// and it shouldn't cause a problem if it is the same
+				// Send an On msg if currently Off or this is an override
+				// Send an Off if currently On
 				if (stateSwitch) {
 					if (!oldStateSwitch || msg.payload.override) {
 						doTimer(msg.payload.timeout);

--- a/smartswitch/smartswitch.js
+++ b/smartswitch/smartswitch.js
@@ -64,9 +64,7 @@ module.exports = function(RED) {
 					msg.payload = 0;
 				}
 
-				// Ignore sync messages for 2 seconds
-				ignoreSync = true;
-				setTimeout(function() {ignoreSync = false;}, 2000);
+				setIgnoreSync();
 				
 				node.send(msg);
 			};
@@ -84,12 +82,15 @@ module.exports = function(RED) {
 					msg.payload = 1;
 				}
 
-				// Ignore sync messages for 2 seconds
-				ignoreSync = true;
-				setTimeout(function() {ignoreSync = false;}, 2000);
+				setIgnoreSync();
 
 				node.send(msg);
 			};
+
+			var setIgnoreSync = function() {
+				ignoreSync = true;
+				setTimeout(function() {ignoreSync = false;}, 4000);
+			}
 
 			var doTimer = function(override) {
 				node.debug(`doTimer with override:${override}`);

--- a/smartswitch/smartswitch.js
+++ b/smartswitch/smartswitch.js
@@ -14,6 +14,9 @@
   limitations under the License.
 
 */
+
+'use strict';
+
 String.prototype.endsWith = function(suffix) {
     return this.match(suffix+"$") == suffix;
 };
@@ -22,15 +25,14 @@ module.exports = function(RED) {
 	function SmartSwitchNode(config) {
 		RED.nodes.createNode(this,config);
 		var node = this;
-		node.timeout = config.timeout * 1000;
-
+		
 		var stateSwitch = false;	// current state
 		var stateTimer = true;	// Enforce or Ignore timer
 		var tout;				// Timer control
+		var finishTime;			// Time when the timer was started
 
 		this.on('input', function(msg) {
 			console.log(msg);
-			var old = stateSwitch;	// Check change?
 
 			var doState = function() {
 				if (stateTimer)
@@ -49,70 +51,117 @@ module.exports = function(RED) {
 				stateSwitch = false;
 				tout = null;
 				doState();
-				msg.autooff = autoOff ? 1 : 0;	// Useful autoOff
-				msg.topic = config.topic;
-				msg.payload = 0;
+
+				let msg = {};
+				if (config.offMsg) {
+					msg = RED.util.evaluateNodeProperty(config.offMsg, 'json', node);;
+				}
+				else {
+					msg.autooff = autoOff ? 1 : 0;	// Useful autoOff
+					msg.topic = config.topic;
+					msg.payload = 0;
+				}
 				node.send(msg);
 			};
 
-			var doOn = function() {
+			var doOn = function(onMsg) {
 				doState();
-				msg.topic = config.topic;
-				msg.payload = 1;
+				
+				let msg = {};
+				if (onMsg) {
+					msg = onMsg;
+				}
+				else {
+					msg.topic = config.topic;
+					msg.payload = 1;
+				}
 				node.send(msg);
 			};
 
 			var doTimer = function(overload) {
 				if (tout) clearTimeout(tout);
-				if ( (overload || node.timeout) && stateTimer) {
+
+				let timeout = (overload ? parseInt(overload) : config.timeout) * 1000;
+
+				if (timeout && stateTimer) {
+					finishTime = Date.now() + timeout;
 					tout = setTimeout(function() {
 						doOff(true);
-					},overload ? overload : node.timeout);
+					}, timeout);
 				}
 			};
 
-			// Inputs
-			if (msg.topic == 'toggle')
-				stateSwitch = !stateSwitch;
-			else if (msg.topic == 'state')
+			var getTimeLeft = function () {
+				return Math.ceil((finishTime - Date.now()) / 1000);
+			}
+
+			// Used to ensure the state is in sync with the actual device 
+			if (msg.topic == 'sync') {
+				let oldStateSwitch = stateSwitch; 
 				stateSwitch = parseInt(msg.payload) > 0;
-			else if (msg.topic.endsWith("/ON"))
-				stateSwitch = true;
-			else if (msg.topic.endsWith("/OFF"))
-				stateSwitch = false;
-			else if (msg.topic.endsWith("/SWAP"))
-				stateSwitch = !stateSwitch;
-			else if (msg.topic.endsWith("/DISABLE"))
-				stateTimer = false;
-			else if (msg.topic.endsWith("/ENABLE"))
-				stateTimer = true;
-			else if (msg.topic.endsWith("/RESET"))
-				doTimer();
+				doState();
+
+				// If the actual device has been turned on start the timer with the default timeout
+				if (stateSwitch && !oldStateSwitch)
+					doTimer();
+			}
+
+			// Just enables and disables the timer but doesn't reset it or cancel it	
 			else if (msg.topic == 'set') {
 				stateTimer = parseInt(msg.payload) > 0;
 				doState();
 			}
-			else if (msg.topic == 'reset') 
-				doTimer();
-			else if (msg.topic == 'timeout') 
-				// XXX I think I have reversed set and timeout - see docs
-				if (stateSwitch && stateTimer)
-					doTimer(parseInt(msg.payload) * 1000);
+			else if (msg.topic.endsWith("/DISABLE")) {
+				stateTimer = false;
+				doState();
+			}
+			else if (msg.topic.endsWith("/ENABLE")) {
+				stateTimer = true;
+				doState();
+			}
 
-			// Outputs? (only if changed?)
-			if (old != stateSwitch) {
-				if (stateSwitch) {
+			else if (msg.topic == 'reset' || msg.topic.endsWith("/RESET")) {
+				// Reset can also turn on if off 
+				if ( !stateSwitch && msg.payload && parseInt(msg.payload) != 0) {
+					stateSwitch = true;
+					doOn(msg.payload.onMsg);
+				}
+
+				// Only reset if timeout was overriden with longer time
+				if ( getTimeLeft() < config.timeout)
 					doTimer();
-					doOn();
+			}
+
+			else {
+				// These commands all cause an on or off msg to be sent
+				if (msg.topic == 'toggle')
+					stateSwitch = !stateSwitch;
+				else if (msg.topic == 'state')
+					stateSwitch = parseInt(msg.payload) != 0;
+				else if (msg.topic.endsWith("/ON"))	
+					stateSwitch = true;
+				else if (msg.topic.endsWith("/OFF")) 
+					stateSwitch = false;
+				else if (msg.topic.endsWith("/SWAP")) 
+					stateSwitch = !stateSwitch;
+				
+				// Nothing needs to be done for a timeout as the timer will always be reset
+				// else if (msg.topic == 'timeout') 
+				//  	if (stateSwitch && stateTimer)
+				//  		doTimer(msg.payload.timeout);
+
+				// Always send an On or Off as there may be a change in onMsg
+				// and it shouldn't cause a problem if it is the same
+				if (stateSwitch) {
+					doTimer(msg.payload.timeout);
+					doOn(msg.payload.onMsg);
 				}
 				else {
 					if (tout) clearTimeout(tout);
 					doOff(false);
 				}
 			}
-
 		});
-
 	}
 	RED.nodes.registerType("smartswitch",SmartSwitchNode);
 }

--- a/smartswitch/smartswitch.js
+++ b/smartswitch/smartswitch.js
@@ -30,6 +30,7 @@ module.exports = function(RED) {
 		var stateTimer = true;	// Enforce or Ignore timer
 		var tout;				// Timer control
 		var finishTime;			// Time when the timer was started
+		var ignoreSync = false; // Whether to ignore sync messages for a brief time
 
 		this.on('input', function(msg) {
 			node.debug(`input event with ${JSON.stringify(msg)}`);
@@ -62,6 +63,11 @@ module.exports = function(RED) {
 					msg.topic = config.topic;
 					msg.payload = 0;
 				}
+
+				// Ignore sync messages for 2 seconds
+				ignoreSync = true;
+				setTimeout(function() {ignoreSync = false;}, 2000);
+				
 				node.send(msg);
 			};
 
@@ -77,6 +83,11 @@ module.exports = function(RED) {
 					msg.topic = config.topic;
 					msg.payload = 1;
 				}
+
+				// Ignore sync messages for 2 seconds
+				ignoreSync = true;
+				setTimeout(function() {ignoreSync = false;}, 2000);
+
 				node.send(msg);
 			};
 
@@ -113,6 +124,12 @@ module.exports = function(RED) {
 			// Used to ensure the state is in sync with the actual device 
 			if (msg.topic == 'sync') {
 				node.debug(`sync called with payload:${msg.payload}`);
+
+				if (ignoreSync) {
+					node.debug(`sync ignored`);
+					return;
+				}
+
 				let oldStateSwitch = stateSwitch; 
 				stateSwitch = parseInt(msg.payload) > 0;
 				doState();

--- a/smartswitch/smartswitch.js
+++ b/smartswitch/smartswitch.js
@@ -135,10 +135,11 @@ module.exports = function(RED) {
 				stateSwitch = parseInt(msg.payload) > 0;
 				doState();
 
-				// If the actual device has been turned on start the timer with the default timeout
+				// If the actual device has been turned on start the timer with the timeout passed
+				// or the default 
 				if (stateSwitch && !oldStateSwitch) {
 					node.debug("sync set timer");
-					doTimer();
+					doTimer(msg.payload.timeout);
 				}
 			}
 

--- a/smartswitch/smartswitch.js
+++ b/smartswitch/smartswitch.js
@@ -132,7 +132,7 @@ module.exports = function(RED) {
 				}
 
 				let oldStateSwitch = stateSwitch; 
-				stateSwitch = parseInt(msg.payload) > 0;
+				stateSwitch = parseInt(msg.payload.state) > 0;
 				doState();
 
 				// If the actual device has been turned on start the timer with the timeout passed

--- a/smartswitch/smartswitch.js
+++ b/smartswitch/smartswitch.js
@@ -131,9 +131,10 @@ module.exports = function(RED) {
 				doState();
 			}
 
-			else if (msg.topic == 'timeout') 
+			else if (msg.topic == 'timeout') {
 				if (stateSwitch && stateTimer)
 					doTimer(msg.payload.timeout);
+			}
 
 			else if (msg.topic == 'reset' || msg.topic.endsWith("/RESET")) {
 				stateTimer = true;

--- a/smartswitch/smartswitch.js
+++ b/smartswitch/smartswitch.js
@@ -112,7 +112,7 @@ module.exports = function(RED) {
 
 			// Used to ensure the state is in sync with the actual device 
 			if (msg.topic == 'sync') {
-				node.debug(`sync called with payload:${msg/payload}`);
+				node.debug(`sync called with payload:${msg.payload}`);
 				let oldStateSwitch = stateSwitch; 
 				stateSwitch = parseInt(msg.payload) > 0;
 				doState();

--- a/smartswitch/smartswitch.js
+++ b/smartswitch/smartswitch.js
@@ -32,7 +32,7 @@ module.exports = function(RED) {
 		var finishTime;			// Time when the timer was started
 
 		this.on('input', function(msg) {
-			console.log(msg);
+			node.debug(`input event with ${JSON.stringify(msg)}`);
 
 			var doState = function() {
 				if (stateTimer)
@@ -48,6 +48,7 @@ module.exports = function(RED) {
 			};
 
 			var doOff = function(autoOff) {
+				node.debug(`doOff with autoOff:${autoOff}`);
 				stateSwitch = false;
 				tout = null;
 				doState();
@@ -65,6 +66,7 @@ module.exports = function(RED) {
 			};
 
 			var doOn = function(onMsg) {
+				node.debug(`doOn with onMsg:${JSON.stringify(onMsg)}`);
 				doState();
 				
 				let msg = {};
@@ -79,6 +81,7 @@ module.exports = function(RED) {
 			};
 
 			var doTimer = function(override) {
+				node.debug(`doTimer with override:${override}`);
 				if (tout) clearTimeout(tout);
 
 				// If the specified timeout is 0 then no timeout
@@ -99,6 +102,7 @@ module.exports = function(RED) {
 						if (stateTimer)
 							doOff(true);
 					}, timeout);
+					node.debug(`Timer set to ${timeout/1000} secs, finishtime:${(new Date(finishTime)).toLocaleString('en-GB', { timeZone: 'UTC' })}`);
 				}
 			};
 
@@ -108,13 +112,16 @@ module.exports = function(RED) {
 
 			// Used to ensure the state is in sync with the actual device 
 			if (msg.topic == 'sync') {
+				node.debug(`sync called with payload:${msg/payload}`);
 				let oldStateSwitch = stateSwitch; 
 				stateSwitch = parseInt(msg.payload) > 0;
 				doState();
 
 				// If the actual device has been turned on start the timer with the default timeout
-				if (stateSwitch && !oldStateSwitch)
+				if (stateSwitch && !oldStateSwitch) {
+					node.debug("sync set timer");
 					doTimer();
+				}
 			}
 
 			// Just enables and disables the timer but doesn't reset it or cancel it	


### PR DESCRIPTION
Hi,

I added the a passthrough feature so that dimming level and colour could be set.

I also tweaked the timeout feature so that an On message can specify it and so that resetting it only does so if there is less time on timer remaining. This feature is useful for motion control so that a motion activation doesn't override an existing scene.

My motion detection sends a start and stop so I had to stop the timer from sending an Off message when there is motion and then start it again when the motion stops.

I also added a sync feature which gets the node back in sync with the actual device which I needed for when the light is turned on manually.

I'm happy to provide example flows to show all this.

It should all be backwards compatible but there may be some edge cases where the behaviour is slightly different depending on how it is being used. 